### PR TITLE
Catch missing upstream data entries

### DIFF
--- a/misc/ttn-letterbox-rrd.pm
+++ b/misc/ttn-letterbox-rrd.pm
@@ -32,6 +32,7 @@
 # 20200213/bie: improve layout for Mobile browers, fix RRD database definition to cover 1y instead of 12d
 # 20211030/bie: add support for v3 API
 # 20220218/bie: align config options, do not die in case of RRD updates happen too often
+# 20220219/bie: catch missing raw data entries and use "U" in RRD update
 
 use strict;
 use warnings;
@@ -180,7 +181,12 @@ sub rrd_update($$$) {
   push @data, $timestamp;
 
   for my $rrd_entry (@rrd) {
-    push @data, $$values_hp{$rrd_entry};
+    if (defined $$values_hp{$rrd_entry}) {
+      push @data, $$values_hp{$rrd_entry};
+    } else {
+      # catch undefined data, e.g. happens sometime on 'snr'
+      push @data, "U";
+    };
   };
 
   my $rrd = join(":", @data);

--- a/misc/ttn-letterbox-rrd.pm
+++ b/misc/ttn-letterbox-rrd.pm
@@ -184,7 +184,7 @@ sub rrd_update($$$) {
     if (defined $$values_hp{$rrd_entry}) {
       push @data, $$values_hp{$rrd_entry};
     } else {
-      # catch undefined data, e.g. happens sometime on 'snr'
+      # catch undefined data, e.g. happens sometimes on 'snr'
       push @data, "U";
     };
   };

--- a/misc/ttn-letterbox.cgi
+++ b/misc/ttn-letterbox.cgi
@@ -131,7 +131,7 @@
 # 20220217/bie: fix "counter" related to v3 API
 # 20220217/bie: add support for Salted Hash provided by Authen::Passphrase::SaltedDigest in case of Crypt::SaltedHash (only available on EPEL7) is not installed/available
 # 20220218/bie: add missing 'init_device' hook for POST
-# 20220219/bie: display '*undef* in case a raw data value is missing (.e.g sometimes 'snr' for unknown reason)
+# 20220219/bie: display '*undef* in case a raw data value is missing (e.g. sometimes 'snr' for unknown reason)
 #
 # TODO:
 # - lock around file writes

--- a/misc/ttn-letterbox.cgi
+++ b/misc/ttn-letterbox.cgi
@@ -131,6 +131,7 @@
 # 20220217/bie: fix "counter" related to v3 API
 # 20220217/bie: add support for Salted Hash provided by Authen::Passphrase::SaltedDigest in case of Crypt::SaltedHash (only available on EPEL7) is not installed/available
 # 20220218/bie: add missing 'init_device' hook for POST
+# 20220219/bie: display '*undef* in case a raw data value is missing (.e.g sometimes 'snr' for unknown reason)
 #
 # TODO:
 # - lock around file writes
@@ -1364,7 +1365,9 @@ sub letter($) {
         };
       };
 
-      $response .= "<td" . $bg . " align=\"right\"><font size=-1" . $fc . ">" . $dev_hash{$dev_id}->{'info'}->{$info} . "</font></td>";
+      my $value = $dev_hash{$dev_id}->{'info'}->{$info};
+      $value = "*undef*" if (! defined $value);
+      $response .= "<td" . $bg . " align=\"right\"><font size=-1" . $fc . ">" . $value . "</font></td>";
 
       # check for optional graphics
       if (defined $dev_hash{$dev_id}->{'graphics'}) {


### PR DESCRIPTION
from time to time, "snr" is missing in raw data POST from for unknown reason.

This changes will proper catch this and avoid entries in error log.